### PR TITLE
Persisting selected value on cancel.

### DIFF
--- a/src/js/HomePageSelctor.js
+++ b/src/js/HomePageSelctor.js
@@ -57,7 +57,7 @@ const HomePageSelector = ({ preSelected , update}) => {
 
     const handleCancel = () => {
         setShow(false);
-        setSelectedCountry(localStorage.getItem('countryName') ? { [country] : true} : {});
+        setSelectedCountry(country ? { [country] : true} : {});
         setFilteredCountries(allCountries);
     }
 


### PR DESCRIPTION
Issue:
=====
The previously selected value was not persisting on cancel.


Implementation/Fix:
=============
Persisting selected value on cancel.

Scenario:
======
1. User clicks "Select home country" and select any other country.
2. After selecting the changes, if the user clicks the Cancel button, again he tries to select a home country, Previously selected value is not persisted.

Now previously selected value will be persisted.